### PR TITLE
Corrected bug in update check for repeated data

### DIFF
--- a/ThingSpeakMultichannel001.html
+++ b/ThingSpeakMultichannel001.html
@@ -159,9 +159,9 @@ $(document).ready(function()
                       p[0] = getChartDate(data.created_at);
                       p[1] = parseFloat(v);
                       // get the last date if possible
-                      if (dynamicChart.series[chartSeriesIndex].data.length > 0) 
+                      if (dynamicChart.series[chartSeriesIndex].xData.length > 0) 
                       { 
-                        last_date = dynamicChart.series[chartSeriesIndex].data[dynamicChart.series[chartSeriesIndex].data.length-1].x; 
+                        last_date = dynamicChart.series[chartSeriesIndex].xData[dynamicChart.series[chartSeriesIndex].xData.length-1]; 
                       }
                       var shift = false ; //default for shift
                       // if a numerical value exists and it is a new date, add it


### PR DESCRIPTION
The "Update Chart" functionality had a flaw in checking for repeated data. For whatever reason (I could not find out on the API documenation) the "data" attribute of dynamicChart is always undefined, however accessing the internal implementation attribute "xData" does the trick. I tested this against Highstock JS v6.0.4 (2017-12-15).

You can test this adding console logging to the last_date check

```
if (!isNaN(parseInt(v)) && (p[0] != last_date)) {
  dynamicChart.series[chartSeriesIndex].addPoint(p, true, shift);
} else { window.console && console.log('Downloaded data is repeated') }
```